### PR TITLE
Ignoring the lines starting with '//' when checking the line length

### DIFF
--- a/build-tools/src/main/resources/hawkular-checkstyle/checkstyle.xml
+++ b/build-tools/src/main/resources/hawkular-checkstyle/checkstyle.xml
@@ -89,6 +89,9 @@
 
     <module name="LineLength">
       <property name="max" value="120" />
+      <!-- disable the line length checking for '//' comments because of the annoying fact
+           that build fails when commenting out 120 chars long line (quite common in IDE) -->
+      <property name="ignorePattern" value="^//.*$"/>
     </module>
 
   </module>


### PR DESCRIPTION
When commenting out a bunch of lines/method it's 50:50 that build fails because some line exceeded 120 chars limit.
This has also drawback that people can write comments longer than 120 characters, but I think it's worth changing.

Now, all the projects/modules are relatively small and hence the build time is short, but it gets worse and these types of build failures will get, imho, very annoying. 
