### PR TITLE
HAWKULAR-134 - Moving the asciidoc.mustache to hawkular-build-tools 

### DIFF
--- a/build-tools/src/main/resources/hawkular-documentation/asciidoc.mustache
+++ b/build-tools/src/main/resources/hawkular-documentation/asciidoc.mustache
@@ -1,0 +1,102 @@
+{{!
+    Copyright 2015 Red Hat, Inc. and/or its affiliates
+    and other contributors as indicated by the @author tags.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+}}
+
+== Base Path
+#`{{basePath}}`#
+
+== REST APIs
+{{#apiDocuments}}
+=== {{{description}}}
+
+{{#apis}}
+{{#apiIndex}}==== {{apiIndex}}{{/apiIndex}}
+
+==============================================
+*Endpoint* `{{path}}`
+
+{{#operations}}
+
+NOTE: *{{summary}}* {{#notes}}+
+      _{{{notes}}}_{{/notes}}
+
+*Method*
+****
+*{{httpMethod}}* `{{path}}`
+****
+
+{{#parameters}}
+*{{paramType}} parameters*
+
+[options="header"]
+|=======================
+|Parameter|Required|Description|Data Type
+{{#paras}}
+    |{{name}}|{{required}}|{{description}}|{{#linkType}}<<{{linkType}},{{type}}>>{{/linkType}}{{^linkType}}{{type}}{{/linkType}}
+{{/paras}}
+|=======================
+{{/parameters}}
+
+{{#responseClass}}
+*Response* +
+{{^className}}void{{/className}}{{#className}}{{className}}{{/className}}
+{{/responseClass}}
+
+*Status codes*
+[options="header"]
+|=======================
+| Status Code | Reason      | Response Model
+{{#errorResponses}}
+| {{code}}    | {{message}} | {{#linkType}}[{{type}}](#<<{{linkType}}>>){{/linkType}}{{^linkType}}{{#type}}{{{type}}}{{/type}}{{^type}}-{{/type}}{{/linkType}}
+{{/errorResponses}}{{^errorResponses}}No codes specified{{/errorResponses}}
+|=======================
+
+{empty} +
+{{/operations}}
+
+==============================================
+
+{empty} +
+
+{{/apis}}
+{{/apiDocuments}}
+
+== Data Types
+
+{empty} +
+{{#dataTypes}}
+
+[[{{name}}]]
+=== {{name}}
+[options="header"]
+|=======================
+| Name | Type | Required | Description | Allowable Values
+{{#items}}
+|{{name}}|{{type}}|{{#required}}required{{/required}}{{^required}}optional{{/required}}|{{#description}}{{{description}}}{{/description}}{{^description}}-{{/description}}|{{#allowableValue}}{{{allowableValue}}}{{/allowableValue}}{{^allowableValue}}-{{/allowableValue}}
+{{/items}}
+|=======================
+
+{{/dataTypes}}
+
+{{#enumTypes}}
+    ## {{name}}
+    {{#allowableValues}}
+        {{.}}
+    {{/allowableValues}}
+{{/enumTypes}}
+{empty} +
+{empty} +
+{empty} +


### PR DESCRIPTION
..to increase the chance that it will available during off-line builds. Build-tools should be a transitive dependency of each hawkular module, because hawkular-parent depends on it.
